### PR TITLE
Correct enums doc + add example

### DIFF
--- a/docs/packages/helpers.md
+++ b/docs/packages/helpers.md
@@ -43,8 +43,33 @@ Methods:
 #### Enum
 
 Provides enumeration like capabilities and may be used in 2 modes:
-a) when given a static 'data' parameter, which should be an associative array
-b) when declaring constants on the class
+a) by declaring a static `attributes` function, which should return an associative array
+b) by declaring constants on the class, these will be flipped (_value_ becomes the stored key)
+
+As an example, _titles_ can be declared either using method a:
+```php
+class Titles extends Enum
+{
+    public static function attributes()
+    {
+        return [
+            1 => 'Miss',
+            2 => 'Ms.',
+            3 => 'Mr.',
+        ];
+    }
+}
+```
+or method b:
+```php
+class Titles extends Enum
+{
+    const Miss = 1;
+    const Ms = 2;
+    const Mr = 3;
+}
+```
+As you can see, method a gives you more freedom towards the value, but can not be used as a constant.
 
 Methods:
  - `get(key)`, returns the value of that Enum key


### PR DESCRIPTION
Note that while testing the possibilities I noticed that constants take precedence over the array in display.

To enhance flexibility (allow "proper" values whilst still having constants to use elsewhere) I believe attributes() should be checked first.

This way, constants can be defined for use in-code whilst UI output is the string declared in attributes